### PR TITLE
Use jsdeliver cdn for plugins.js

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,9 +120,9 @@
         typographer: true,
       });
     </script>
-    <script src="https://raw.githubusercontent.com/JoshAtticus/leo/main/plugins.js" type="text/javascript"></script>
+    <script src="https://cdn.jsdelivr.net/gh/JoshAtticus/leo@main/plugins.js" type="text/javascript"></script>
     <script src="script.js" type="text/javascript"></script>
-    <script src="https://raw.githubusercontent.com/JoshAtticus/leo/main/plugins.js" type="text/javascript"></script>
+    <script src="https://cdn.jsdelivr.net/gh/JoshAtticus/leo@main/plugins.js" type="text/javascript"></script>
     <script src="markdown.js" type="text/javascript"></script>
     <script src="emoji.js" type="text/javascript"></script>
     <script type="text/javascript">


### PR DESCRIPTION
GitHub uses CORS now so that doesn't work anymore.