### PR TITLE
Fix plugins

### DIFF
--- a/script.js
+++ b/script.js
@@ -2219,7 +2219,7 @@ function loadPluginScript(scriptUrl) {
     })
     .then(response => response.text())
     .then(data =>{
-        eval(data);
+        window.eval(data);
     })
     .catch(error => console.error('Error:', error));
 }


### PR DESCRIPTION
fix plugins that do global scope stuff by running eval on global scope (`window.eval()` instead of just `eval()`)